### PR TITLE
Fixing incorrect path

### DIFF
--- a/cmd/_template/repo/internal/pkg/metrics/push.go
+++ b/cmd/_template/repo/internal/pkg/metrics/push.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"time"
 
-	"github.com/fresh8gaming/megalith/internal/pkg/logging"
+	"github.com/{{ .Org }}/{{ .Name }}/internal/pkg/logging"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"


### PR DESCRIPTION
```go: finding module for package github.com/fresh8gaming/megalith/internal/pkg/logging
github.com/fresh8gaming/search-ads/internal/pkg/metrics imports
	github.com/fresh8gaming/megalith/internal/pkg/logging: cannot find module providing package github.com/fresh8gaming/megalith/internal/pkg/logging: module github.com/fresh8gaming/megalith/internal/pkg/logging: git ls-remote -q origin in /Users/chrisaugier/go/pkg/mod/cache/vcs/d0a61d22247cf37ccd17dc79cada7458a409d8dcd2a0ba5044be5e3e4e9f4508: exit status 128:```